### PR TITLE
Add Code of Conduct to the website

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -10,5 +10,10 @@ summaryLength = 10
   description = "Join our community-owned network to replace your current internet connection."
   images = ["/img/3d.png"]
 
-[blackfriday]
-hrefTargetBlank = true
+[markup]
+	[markup.blackFriday]
+		hrefTargetBlank = true
+	[markup.tableOfContents]
+		endLevel = 3
+		ordered = false
+		startLevel = 2

--- a/content/coc/index.md
+++ b/content/coc/index.md
@@ -1,0 +1,104 @@
+---
+layout: page
+title: "Code of Conduct"
+toc: true
+---
+
+NYC Mesh is dedicated to fostering an environment in which everyone can participate in our meetups, installs, online spaces, and any other community event.
+
+We believe that diversity in our community is critical and should be celebrated.
+We welcome everyone of any race, age, gender, nationality, gender identity and expression, sexual orientation, disability, physical appearance, body size, religion, education, and skill level.
+The NYC Mesh community and experience often extends outside those spaces.
+Members meet in person to collaborate on projects, attend related meetups or conferences together, and communicate on social media.
+Abusive or unwelcoming behavior between NYC Mesh Members still has a profound impact on individuals and on the community when it happens beyond our events and online forums.
+We will use our discretion when deciding whether to enforce this code of conduct after reports of such behavior happening outside of our spaces, taking into account the impact on the individual Members involved as well as the impact on the community at large.
+
+## Types of Behavior
+
+### Encouraged Behavior
+
+All participants are expected to: be considerate, respectful, and collaborative. Specifically we expect participants to:
+* Demonstrate empathy, kindness, and patience toward other people
+* Assume the best intentions from others
+* Be respectful of differing opinions, viewpoints, and experiences
+* Give and gracefully accepting constructive feedback
+* Accept responsibility and apologize to those affected by our mistakes, and learn from the experience
+* Focus on what is best not just for us as individuals, but for the overall community
+
+
+### Unacceptable Behavior
+
+The following types of behavior are unacceptable at NYC Mesh, both online and in-person, and constitute code of conduct violations.
+
+#### Abusive Behavior
+
+* **Harassment** — including offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, nationality, immigration status, language, religion, or education level, as well as sexual images in public spaces, deliberate intimidation or bullying, stalking, following, harassing photography or recording, inappropriate physical contact, and unwelcome sexual or romantic attention.
+* **Threats** — threatening someone physically or verbally. For example, threatening to publicize sensitive information about someone’s personal life.
+
+
+#### Unwelcoming Behavior
+
+* **Blatant -isms** — saying things that are explicitly racist, sexist, homophobic, etc. For example, arguing that some people are less intelligent because of their gender, race or religion. [Subtle -isms](https://www.recurse.com/social-rules#no-subtle-isms) and small mistakes made in conversation are not code of conduct violations. However, repeating something after it has been pointed out to you that you made a member feel unwelcome, broke a social rule, or antagonizing or arguing with someone who has pointed out your subtle -ism is considered unwelcoming behavior, and is not allowed in NYC Mesh.
+* **Maliciousness towards other Members** — deliberately attempting to make others feel bad, name-calling, singling out others for derision or exclusion. For example, telling someone they’re not technical enough, or that they don’t belong in NYC Mesh.
+* **Being especially unpleasant** — for example, if we’ve received reports from multiple members of annoying, rude, or especially distracting behavior. For example, repeatedly engaging in bad faith arguments, talking down to people, or excluding people from participation.
+
+## Reporting
+
+Please report code of conduct violations either to the event organizer, by emailing [safe@nycmesh.net](mailto:safe@nycmesh.net) or by alerting moderators on Slack with the `@moderators` group tag.
+
+All of our moderators are volunteers, and will respond with their best effort. However, if you provide your name, or contact info we promise to respond within two business days.
+
+### How to Report
+
+In your report, please include:
+* **Your name** — this is incredibly helpful for us to be able to follow up with you, and ask questions to better understand the situation. You are welcome to report anonymously. Please only use this option if you really need to, and know that we might not be able to take action without knowing who you are. In any case, provide an email address so we can correspond with you about the report.
+* **A detailed description of what happened**
+	* If the violation happened online, please link to or send us the relevant text.
+	* If the violation happened in person, please detail exactly what the other person said or did. In order to take action, we need to know the concrete actions that someone took.
+* **Where and when the incident happened**
+* **Any other relevant context**. Do you have examples of a pattern of similar behavior from this person before? Do you have a relationship with this person outside of NYC Mesh?
+* **If/how you’ve already responded** — this lets us know the current state of the situation.
+
+
+### Why to Report
+
+* **You are Responsible for making NYC Mesh a safe and comfortable space for everyone.** Everyone in our community shares this responsibility. Our volunteer Mesh Moderators are not around all the time, so we cannot enforce the code of conduct without your help.
+* **The consequences for NYC Mesh of not reporting bad behavior outweigh the consequences for one person of reporting it.** We sometimes hear “I don’t want X person to meet consequences because I told someone about their bad behavior.” Consider the impact on everyone else at NYC Mesh of letting their behavior continue unchecked.
+* NYC Mesh only works as a self-directed, community-driven effort because of shared trust between members. **Reporting code of conduct violations helps us identify when this trust is broken, to prevent that from happening in the future.**
+
+
+## Enforcement Guidelines
+
+Moderators will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct.
+
+### Correction
+
+Community Impact: Unwelcoming behavior. Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+Consequence: A private, written warning from moderators, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested in the venue where the behavior took place, for example on Slack or at the event.
+
+
+### Warning
+
+Community Impact: A violation through a single incident of abusive behavior or series of unwelcoming behaviors.
+
+Consequence: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### Temporary Ban
+Community Impact: A serious violation of community standards, including sustained unwelcoming behavior.
+
+Consequence: A temporary ban from any sort of participation, interaction, or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+
+### Permanent Ban
+Community Impact: Demonstrating a pattern of violation of community standards, including sustained unwelcoming behavior, harassment or threatening of an individual, or aggression toward or disparagement of classes of individuals.
+
+Consequence: A permanent ban from any sort of participation, or public interaction within the community.
+
+
+## Discussion
+If you have questions about any aspect of the code of conduct, or want to propose amending it, please contact the `@moderators` group, or drop in to the public [#code-of-conduct](https://nycmesh.slack.com/messages/code-of-conduct) channel on Slack.
+
+## Attribution
+Most of this is from the [Recurse Center CoC](https://www.recurse.com/code-of-conduct).
+Other parts are from [Strange Loop](https://thestrangeloop.com/policies.html)(community goals), [Contributor Covenant](https://www.contributor-covenant.org/version/2/0/code_of_conduct) (portion of the community goals, encouraged behaviors, enforcement guidelines), and the [Toronto Mesh](https://github.com/tomeshnet/documents/blob/master/governance/conduct-guidelines.md)/[Geek Feminism](https://geekfeminism.wikia.org/wiki/Conference_anti-harassment/Responding_to_reports) (guidelines for moderators).

--- a/content/modguide/index.md
+++ b/content/modguide/index.md
@@ -1,0 +1,66 @@
+---
+layout: page
+title: "Moderator Guide"
+toc: true
+---
+
+This guide documents protocols for moderators on how to respond to reports of conduct violations, the expectations of our moderators, and how to become a moderator.
+
+## Responding to a Code of Conduct report
+
+If someone reports unacceptable behavior, ask for a written account of what happened.
+This should be kept confidential to as small a group as reasonably possible, and potentially anonymised by the receiving person before distribution to the closed group.
+If organizers receive a verbal report, they should themselves write down what they were told as soon as they can.
+If a report is made anonymously without an email address provided for follow-up, or if the reporter indicates that they do not give us permission to act on their report, we will unfortunately not be able to take any action.
+
+Within two business days of receiving a report, you will complete the following steps.
+
+### First Steps
+
+If the following information is not volunteered in a report, ask for it/include it, but do not pressure anyone:
+* Identifying information of the participant doing the harassing
+* The behavior that was in violation
+* The approximate time of the behavior (if different than the time the report was made)
+* The circumstances surrounding the incident
+* Other people involved in the incident
+
+### Determine whether a violation occurred
+
+Review the details of the report, and read the Code of Conduct.
+You must be able to specifically reference a behavior documented in the Code of Conduct.
+* If not, reply to the reporter, explain that our code of conduct was not violated, and suggest other remediation options (e.g. getting advice on how to resolve an interpersonal conflict).
+* If yes, determine whether you are the best person to respond to the situation, or if it is more appropriate to hand off the report to another moderator (for example, if someone else already has a relationship with the reporter or the accused).
+
+### Follow up with the reporter
+
+When a report has been received:
+* Email the reporter to acknowledge that we’ve received the report, and are taking action
+* Ask any follow-up questions we need to better understand the situation
+* Confirm with the reporter whether we can contact the accused individual
+
+
+### Follow up with the violator
+
+In the event that we have permission from the reporter to contact the violator:
+* Reach out to the member over email, let them know that we’ve received a report of a code of conduct violation, and invite them to speak to us about the incident in person if possible, over video chat if not.
+* If you determine that a code of conduct violation has occurred, explain to the member how it affected our community, and what the appropriate consequence is.
+
+## Becoming a moderator
+
+We welcome anyone to become a moderator!
+
+Because moderators work with sensitive information, we do require some education and training. In particular this includes reading and being familiar with the Code of Conduct.
+
+If you are interested in becoming a moderator, please ping the `@moderators` slack group, and someone will be in touch!
+
+### Responsibilities
+
+Moderators should first and foremost ensure the privacy of all community members.
+This means not sharing any details of interpersonal conflict in public.
+All reports should be handled with the narrowest scope possible.
+
+For this reason, we have created a private #mods channel for discussing the details of a report.
+
+## Attribution
+
+The [Toronto Mesh](https://github.com/tomeshnet/documents/blob/master/governance/conduct-guidelines.md)/[Geek Feminism](https://geekfeminism.wikia.org/wiki/Conference_anti-harassment/Responding_to_reports).

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,6 +6,9 @@
 			<h1 class="mv0 f3 fw7">
 				{{ .Title }}
 			</h1>
+			{{ if (.Params.toc) }}
+				{{.TableOfContents}}
+			{{end}}
 			{{ .Content }}
 		</div>
 	</div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -16,6 +16,7 @@
 					<li class="mv2"><a href="/volunteer" class="link mid-gray">Volunteer</a></li>
 					<li class="mv2"><a href="/newsletter" class="link mid-gray">Newsletter</a></li>
 					<li class="mv2"><a href="/blog" class="link mid-gray">Blog</a></li>
+					<li class="mv2"><a href="/coc" class="link mid-gray">Code of Conduct</a></li>
 				</ul>
 			</div>
 			<div class="w-20-l w-50 mb0-l mb4">


### PR DESCRIPTION
This PR adds a link to the CoC in the footer, and introduces two new pages: `/coc` and `/modguide`.