### PR TITLE
Update the Slack redirect in the footer for non-members

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -2,7 +2,7 @@
 /data			/faq/#data
 /peering        https://docs.nycmesh.net/networking/peering/
 /youtube		https://www.youtube.com/channel/UC3FH_8A4SDtJbo5UWMhBteA
-/slack		https://join.slack.com/t/nycmesh/shared_invite/enQtNDk0NDA4OTAyNDY0LTU5NWMyODY5ZTYyMDY2NzgzOTJmZjFmZTg3YWRjYjE0M2EyMzlhNDE3YmIxZmZhYTZmNjIwNTVkMDIwMjI2ZDg
+/slack		https://slack.nycmesh.net/
 /leaflet	https://docs.nycmesh.net/organization/outreach/
 /blog/ethernet	https://docs.nycmesh.net/hardware/ethernet/
 /cpe	https://docs.nycmesh.net/hardware/config/#lbe-client


### PR DESCRIPTION
**Fixes**:
#102 

**Problem:**
If you are not an existing member of the NYC Mesh Slack group, navigating to `https://www.nycmesh.net/slack` results in an expired Slack invite link page. Best reproduced in an incognito tab.

**Solution**:
Use the URL found in the footer as the redirect URL.

**Context**:
Unsure whether it should point to `https://slack.nycmesh.net/` (which ultimately resolves to `https://join.slack.com/t/nycmesh/shared_invite/zt-a60pusap-syb6K0iFD7MQZBflLKNuJA`) or point directly to the redirected join.slack.com URL. I'm guessing that the join.slack.com URL is subject to change, so pointing to slack.nycmesh.net seems like the correct solution here. Additionally, the footer partials also uses `https://slack.nycmesh.net/`.