### PR TITLE
Adds payment installation link to footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -36,6 +36,7 @@
 					<li class="mv2"><a href="https://los.nycmesh.net" class="link mid-gray" target="_">Line of Sight</a></li>
 					<li class="mv2"><a href="/presentations" class="link mid-gray">Presentations</a></li>
 					<li class="mv2"><a href="https://docs.nycmesh.net/organization/outreach/" class="link mid-gray" target="_">Outreach</a></li>
+					<li class="mv2"><a href="/pay" class="link mid-gray" target="_">Install Payment</a></li>
 				</ul>
 			</div>
 			<div class="w-20-l w-50">


### PR DESCRIPTION
**Fixes**:
#100 

**Problem:**
No link to installation payment visible in footer

**Solution**:
Add a link to `/pay` in the footer

**Context**:
Couple of questions here:

1. Unsure whether Resources was the right category to place this link under. However, thinking from an installer's perspective, putting it here and as the last item makes it easy for installers to simply tell an installee "Please go to nycmesh.net, scroll to the bottom and click on the last linked labeled 'Install Payment' under Resources".
2. Was unsure whether to use sentence case or title case. I followed the pattern of "Line of Sight" and "Code of Conduct" being title-cased.
3. Is it confusing to users to have both a donate page and an installation payment page while one is in the header and other is in the footer?