### PR TITLE
Fix link to cost section

### DIFF
--- a/content/faq/index.md
+++ b/content/faq/index.md
@@ -210,7 +210,7 @@ Some additional things you can do to determine if you are in a coverage zone:
 
 ### <a name="alsouse"></a>My neighbor has a rooftop router and is connected to NYC Mesh. Can I also use it to connect?
 
-We encourage neighbors to share their Internet access. Ask your neighbor for permission to connect via their rooftop router and reach out to us on [Slack](https://slack.nycmesh.net/). We can probably install a switch at the rooftop router and run an ethernet cable to your apartment. If you’re connecting to a neighbor we still suggest that you contribute at the levels described above (see Is there a cost to join?[link]). We also suggest a recurring $20, $30, $50 or $60 monthly donation if you can afford it.
+We encourage neighbors to share their Internet access. Ask your neighbor for permission to connect via their rooftop router and reach out to us on [Slack](https://slack.nycmesh.net/). We can probably install a switch at the rooftop router and run an ethernet cable to your apartment. If you’re connecting to a neighbor we still suggest that you contribute at the levels described above (see [Is there a cost to join?](#cost)). We also suggest a recurring $20, $30, $50 or $60 monthly donation if you can afford it.
 
 ### <a name="waittime"></a>What is the wait time for a volunteer-led installation? How do you decide who to connect first?
 


### PR DESCRIPTION
The markdown was missing the correct link.

Before:
![image](https://user-images.githubusercontent.com/39505100/140622432-b12412d2-860a-46b9-8e58-a1885e315bfd.png)

Proposed changes:
![image](https://user-images.githubusercontent.com/39505100/140622417-1f750b85-b4ae-484d-aef3-f8bbe5248f86.png)
