### PR TITLE
add /n/greenpoint page for Greenpoint onboarding

### DIFF
--- a/content/n/_index.md
+++ b/content/n/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Neighborhoods"
+---
+

--- a/content/n/greenpoint.md
+++ b/content/n/greenpoint.md
@@ -1,0 +1,29 @@
+---
+title: "Greenpoint"
+description: "Greenpoint"
+tags: [neighborhood, greenpoint, north-brooklyn]
+date: "2021-11-08"
+---
+
+NYC Mesh is getting Greenpoint connected with reliable, community owned internet, and can use your help!
+
+## Get Connected
+
+If you can see one or more of [these hubs](https://nycmesh.net/map/nodes/115-1084-2090-1167-5712) from your rooftop or window, there is a good chance you can get online with NYC Mesh.
+
+- [ ] 📸 Go to your roof and take some nice panoramas of the skyline, to determine nearby node visibility
+- [ ] 📝 Fill out the [join form](/join), and include your panoramas.
+- [ ] 🔧 Install your node, either by leading your own [DIY Installation](https://docs.nycmesh.net/diy/), or requesting a [volunteer lead install](/faq#waittime)
+
+## Learn
+
+Interested in helping? Have a question? Curious?
+
+- 📚 Learn more at our [FAQ](/faq) and [NYC Mesh Docs](https://docs.nycmesh.net/)
+- 😎 Join us in the [#n-greenpoint](https://nycmesh.slack.com/archives/C8MEYSG6B) Slack channel
+- 👷🏽‍♀️ Need help with your node? Swing by the [support form](/support)
+
+
+## Map
+
+<iframe src="https://nycmesh.net/map/nodes/115-1084-2090-1167-5712" width=100% height=1000px></iframe>


### PR DESCRIPTION
I am making some flyers for Greenpoint, and wanted to link to a neighborhood-focused onboarding page. I emulated our `#n-<neighborhood>` pattern in slack with the URL path: `nycmesh.net/n/<neighborhood>`.

Heres a rendering of the new page: 
![Screenshot from 2021-11-09 08-55-34](https://user-images.githubusercontent.com/130194/140936833-6d48e412-e92e-4175-89b3-9ba384114ec3.png)




I hope this helps neighborhoods to create neighborhood-specific flyers with this URL in QR, like so: ![qr-name-white-with-n-greenpoint-url-4x4 5](https://user-images.githubusercontent.com/130194/140829238-52e551ea-8d03-4b10-ac97-1e7c96a2dafb.png)
