### PR TITLE
greenpoint: simplify copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 public
 resources/node-map
+/node_modules/
+.hugo_build.lock

--- a/content/n/greenpoint.md
+++ b/content/n/greenpoint.md
@@ -7,23 +7,14 @@ date: "2021-11-08"
 
 NYC Mesh is getting Greenpoint connected with reliable, community owned internet, and can use your help!
 
-## Get Connected
 
-If you can see one or more of [these hubs](https://nycmesh.net/map/nodes/115-1084-2090-1167-5712) from your rooftop or window, there is a good chance you can get online with NYC Mesh.
+Interested? Check out the [FAQ](/faq), then [get connected](/join)!
 
-- [ ] 📸 Go to your roof and take some nice panoramas of the skyline, to determine nearby node visibility
-- [ ] 📝 Fill out the [join form](/join), and include your panoramas.
-- [ ] 🔧 Install your node, either by leading your own [DIY Installation](https://docs.nycmesh.net/diy/), or requesting a [volunteer lead install](/faq#waittime)
+Want to help out? Have a question? Curious?
 
-## Learn
-
-Interested in helping? Have a question? Curious?
-
-- 📚 Learn more at our [FAQ](/faq) and [NYC Mesh Docs](https://docs.nycmesh.net/)
+- 📚 Learn more at our [FAQ](/faq) and [Docs](https://docs.nycmesh.net/)
 - 😎 Join us in the [#n-greenpoint](https://nycmesh.slack.com/archives/C8MEYSG6B) Slack channel
-- 👷🏽‍♀️ Need help with your node? Swing by the [support form](/support)
+- 👷🏽‍♀️ Need support? Swing by the [support form](/support)
 
-
-## Map
 
 <iframe src="https://nycmesh.net/map/nodes/115-1084-2090-1167-5712" width=100% height=1000px></iframe>


### PR DESCRIPTION
I simplified the copy for the Greenpoint neighborhood page, thanks to @OlivierMorf pointing out that the copy for joining was subtly incorrect. We now point people directly to the FAQ instead of duplicating instructions.

Rendered example:

![Screenshot from 2021-11-24 11-25-59](https://user-images.githubusercontent.com/130194/143276794-512e390c-df27-4a3d-9039-2f3b557cab89.png)
