### PR TITLE
Redirect to new status page

### DIFF
--- a/content/network-status-old.md
+++ b/content/network-status-old.md
@@ -3,10 +3,6 @@ title: "Network status"
 aliases: [/status/]
 ---
 
-<meta http-equiv="Refresh" content="0; url='https://status.mesh.nycmesh.net/'" />
-
-Redirecting to the [new network status page](https://status.mesh.nycmesh.net/)
-
 2023-10-4
 
 10:00am We are currently working on a problem at our Henry Street Hub. This is affecting some connections on the Lower East Side

--- a/layouts/shortcodes/redirect_to_status_page.js
+++ b/layouts/shortcodes/redirect_to_status_page.js
@@ -1,0 +1,8 @@
+<div id="status_page_redirect">        
+  <script type="text/javascript">
+  </script>
+  <script>
+		window.location.replace("https://status.mesh.nycmesh.net");
+  </script>
+</div>
+

--- a/layouts/shortcodes/redirect_to_status_page.js
+++ b/layouts/shortcodes/redirect_to_status_page.js
@@ -1,8 +1,0 @@
-<div id="status_page_redirect">        
-  <script type="text/javascript">
-  </script>
-  <script>
-		window.location.replace("https://status.mesh.nycmesh.net");
-  </script>
-</div>
-

--- a/static/_redirects
+++ b/static/_redirects
@@ -9,3 +9,4 @@
 /cpe2	https://docs.nycmesh.net/hardware/config/#lbe-client
 /docs	https://docs.nycmesh.net/
 /panorama/1.7miles.png /img/1.7miles.png
+/network-status https://status.mesh.nycmesh.net


### PR DESCRIPTION
Moves old status page content to `/status-page-old`, and creates a 302 at `/status-page`.