### PR TITLE
Update footer status page link and added notice to old page.

### DIFF
--- a/content/network-status-old.md
+++ b/content/network-status-old.md
@@ -3,6 +3,9 @@ title: "Network status"
 aliases: [/status/]
 ---
 
+<h1>This status page is no longer in use, please see the new status page at [status.nycmesh.net](https://www.status.nycmesh.net)</h1>
+
+
 2023-10-4
 
 10:00am We are currently working on a problem at our Henry Street Hub. This is affecting some connections on the Lower East Side

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -22,7 +22,7 @@
 			<div class="w-20-l w-50 mb0-l mb4">
 				<h4 class="f6 fw5 mt0 mb2 ttu">Network</h4>
 				<ul class="list ma0 pa0 flex flex-column items-start">
-					<li class="mv2"><a href="/network-status" class="link mid-gray">Status</a></li>
+					<li class="mv2"><a href="https://status.nycmesh.net" class="link mid-gray">Network Status</a></li>
 					<li class="mv2"><a href="https://stats.nycmesh.net" class="link mid-gray">Stats</a></li>
 					<li class="mv2"><a href="https://docs.nycmesh.net/networking/peering/" class="link mid-gray">Peering</a></li>
 					<li class="mv2"><a href="/sponsors" class="link mid-gray">Sponsors</a></li>


### PR DESCRIPTION
Updated the footer to the new status page link.
Added notice to old status page that it is no longer in use. (For people with old bookmarks)