### PR TITLE
Add /orgdocs

### DIFF
--- a/content/orgdocs/index.md
+++ b/content/orgdocs/index.md
@@ -1,0 +1,9 @@
+---
+title: "Org Docs"
+---
+
+**NYC Mesh Inc. EIN: 84-2616395**
+
+In the interest of transparency, NYC Mesh will compile and publish all organizational documents for public review. Many of these documents are posted on the Slack, but can now be easily accessed without needing a Slack account.
+
+<iframe src="https://drive.google.com/embeddedfolderview?id=1PphEg_iScPw_twzFXqEPfmSartrCs-Ch#grid" style="width:100%; height:600px; border:0;"></iframe>

--- a/content/orgdocs/index.md
+++ b/content/orgdocs/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Org Docs"
+aliases: ["/orgdocs"]
 ---
 
 **NYC Mesh Inc. EIN: 84-2616395**

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -38,7 +38,7 @@
 					<li class="mv2"><a href="/presentations" class="link mid-gray">Presentations</a></li>
 					<li class="mv2"><a href="https://docs.nycmesh.net/organization/outreach/" class="link mid-gray" target="_">Outreach</a></li>
 					<li class="mv2"><a href="/pay" class="link mid-gray" target="_">Install Payment</a></li>
-					<li class="mv2"><a href="/orgdocs" class="link mid-gray">Org Documents</a></li>
+					<li class="mv2"><a href="/orgdocs" class="link mid-gray">Public Records</a></li>
 				</ul>
 			</div>
 			<div class="w-20-l w-50">

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -38,6 +38,7 @@
 					<li class="mv2"><a href="/presentations" class="link mid-gray">Presentations</a></li>
 					<li class="mv2"><a href="https://docs.nycmesh.net/organization/outreach/" class="link mid-gray" target="_">Outreach</a></li>
 					<li class="mv2"><a href="/pay" class="link mid-gray" target="_">Install Payment</a></li>
+					<li class="mv2"><a href="/orgdocs" class="link mid-gray">Org Documents</a></li>
 				</ul>
 			</div>
 			<div class="w-20-l w-50">


### PR DESCRIPTION
Adding nycmesh.net/orgdocs to main website to replace docs.nycmesh.net/organization/documents