### PR TITLE
Update wiki domain

### DIFF
--- a/content/download/index.md
+++ b/content/download/index.md
@@ -91,7 +91,7 @@ A quick test to see if you are on the mesh is to go here-
 [http://10.100.4.10/](http://10.100.4.10/)
 
 This URL should resolve after an hour or so of being online-  
-[http://wiki.mesh/](http://wiki.mesh/)
+[http://uisp.mesh/](http://uisp.mesh/)
 
 Here are our old TP-Link instructions in case you find an old TL-WR842N on ebay-
 

--- a/content/nn/index.md
+++ b/content/nn/index.md
@@ -33,4 +33,4 @@ If you have the password you can assign a NN for an install number
   <input type="submit" value='Assign NN'>
 </form>
 
-For information about the NN system, please see [the Wiki Network Number page.](https://wiki.mesh.nycmesh.net/link/78#bkmrk-page-title)
+For information about the NN system, please see [the Wiki Network Number page.](https://wiki.nycmesh.net/link/78#bkmrk-page-title)

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -24,18 +24,18 @@
 				<ul class="list ma0 pa0 flex flex-column items-start">
 					<li class="mv2"><a href="https://status.nycmesh.net" class="link mid-gray">Network Status</a></li>
 					<li class="mv2"><a href="https://stats.nycmesh.net" class="link mid-gray">Stats</a></li>
-					<li class="mv2"><a href="https://wiki.mesh.nycmesh.net/link/98#bkmrk-page-title" class="link mid-gray">Peering</a></li>
+					<li class="mv2"><a href="https://wiki.nycmesh.net/link/98#bkmrk-page-title" class="link mid-gray">Peering</a></li>
 					<li class="mv2"><a href="/sponsors" class="link mid-gray">Sponsors</a></li>
 				</ul>
 			</div>
 			<div class="w-20-l w-50 mb0-l">
 				<h4 class="f6 fw5 mt0 mb2 ttu">Resources</h4>
 				<ul class="list ma0 pa0 flex flex-column items-start">
-					<li class="mv2"><a href="https://wiki.mesh.nycmesh.net/books/introduction/page/frequently-asked-questions" class="link mid-gray">FAQ</a></li>
-					<li class="mv2"><a href="https://wiki.mesh.nycmesh.net" class="link mid-gray" target="_">Documentation (Wiki)</a></li>
+					<li class="mv2"><a href="https://wiki.nycmesh.net/books/introduction/page/frequently-asked-questions" class="link mid-gray">FAQ</a></li>
+					<li class="mv2"><a href="https://wiki.nycmesh.net" class="link mid-gray" target="_">Documentation (Wiki)</a></li>
 					<li class="mv2"><a href="https://los.nycmesh.net" class="link mid-gray" target="_">Line of Sight</a></li>
 					<li class="mv2"><a href="/presentations" class="link mid-gray">Presentations</a></li>
-					<li class="mv2"><a href="https://wiki.mesh.nycmesh.net/link/123#bkmrk-page-title" class="link mid-gray" target="_">Outreach</a></li>
+					<li class="mv2"><a href="https://wiki.nycmesh.net/link/123#bkmrk-page-title" class="link mid-gray" target="_">Outreach</a></li>
 					<li class="mv2"><a href="/pay" class="link mid-gray" target="_">Install Payment</a></li>
 					<li class="mv2"><a href="/orgdocs" class="link mid-gray">Public Records</a></li>
 				</ul>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -18,8 +18,8 @@
         </div>
         <nav class="f5 flex items-center dropdown-content pointer-events-none bg-white">
 		<a href="/map" class="ml3-ns black pointer-events">Map</a>
-        <a href="https://wiki.mesh.nycmesh.net/books/introduction/page/frequently-asked-questions" class="ml3-ns black pointer-events">FAQ</a>
-        <a href="https://wiki.mesh.nycmesh.net" class="ml3-ns black pointer-events">Docs/Wiki</a>
+        <a href="https://wiki.nycmesh.net/books/introduction/page/frequently-asked-questions" class="ml3-ns black pointer-events">FAQ</a>
+        <a href="https://wiki.nycmesh.net" class="ml3-ns black pointer-events">Docs/Wiki</a>
         <a href="/blog" class="ml3-ns black pointer-events">Blog</a>
         <a href="https://nycmesh.creator-spring.com/" class="ml3-ns black pointer-events">Merch</a>
         <a href="/support" class="ml3-ns black pointer-events green fw5">Get Support</a>


### PR DESCRIPTION
Please approve but do not merge yet.

Update the wiki domain from `wiki.mesh.nycmesh.net` to `wiki.nycmesh.net`.

The cut over plan is:
1. Start maintenance window
2. Final backup
3. Make wiki read-only
4. Merge https://github.com/nycmeshnet/nycmesh-dns/pull/98
5. Restore backup on new infra
6. Manual domain update command on new infra
7. End maintenance window
8. Merge cleanup stuff
