### PR TITLE
Add GH action to build an artifact for map.nycmesh.net

### DIFF
--- a/.github/workflows/map-build.yaml
+++ b/.github/workflows/map-build.yaml
@@ -50,7 +50,7 @@ jobs:
         run: |
           hugo \
             --minify \
-            --baseURL "https://map.nycmesh.net/"
+            --baseURL "https://nycmesh.net/"
       - name: Build Map Payload
         run:  |
           mkdir -p public/map/img/

--- a/.github/workflows/map-build.yaml
+++ b/.github/workflows/map-build.yaml
@@ -49,6 +49,8 @@ jobs:
           hugo \
             --minify \
             --baseURL "https://map.nycmesh.net/"
+      - name: Build Map Payload
+        run: mkdir -p public/map/map/ && mv public/map/static/ public/map/map/static/
       - name: Publish map site build for map.nycmesh.net to fetch and host
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/map-build.yaml
+++ b/.github/workflows/map-build.yaml
@@ -8,6 +8,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+  # Run every 10 minutes to fetch new map updates from the database and create an artifact with the new data
+  schedule:
+    - cron: "*/10 * * * *"
+
 # Default to bash
 defaults:
   run:

--- a/.github/workflows/map-build.yaml
+++ b/.github/workflows/map-build.yaml
@@ -19,7 +19,7 @@ env:
 jobs:
   # Build job
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       HUGO_VERSION: 0.69.2
     steps:

--- a/.github/workflows/map-build.yaml
+++ b/.github/workflows/map-build.yaml
@@ -55,6 +55,7 @@ jobs:
           mv public/map/static/ public/map/map/static/
           mkdir -p public/map/img/
           mv public/img/map/ public/map/img/map/
+          mv public/favicon.ico public/map/favicon.ico
       - name: Publish map site build for map.nycmesh.net to fetch and host
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/map-build.yaml
+++ b/.github/workflows/map-build.yaml
@@ -4,11 +4,9 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["master"]
-  pull-request:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-  pull_request:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/map-build.yaml
+++ b/.github/workflows/map-build.yaml
@@ -33,9 +33,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v5
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
       - name: Update map
@@ -47,7 +44,7 @@ jobs:
         run: |
           hugo \
             --minify \
-            --baseURL "${{ steps.pages.outputs.base_url }}/"
+            --baseURL "https://map.nycmesh.net/"
       - name: Publish map site build for map.nycmesh.net to fetch and host
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/map-build.yaml
+++ b/.github/workflows/map-build.yaml
@@ -40,6 +40,8 @@ jobs:
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
       - name: Update map
+        env:
+          STANDALONE_MAP_BUILD: true
         run: sh update-map.sh
       - name: Build with Hugo
         env:

--- a/.github/workflows/map-build.yaml
+++ b/.github/workflows/map-build.yaml
@@ -8,18 +8,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
-
 # Default to bash
 defaults:
   run:

--- a/.github/workflows/map-build.yaml
+++ b/.github/workflows/map-build.yaml
@@ -50,7 +50,11 @@ jobs:
             --minify \
             --baseURL "https://map.nycmesh.net/"
       - name: Build Map Payload
-        run: mkdir -p public/map/map/ && mv public/map/static/ public/map/map/static/
+        run:  |
+          mkdir -p public/map/map/
+          mv public/map/static/ public/map/map/static/
+          mkdir -p public/map/img/
+          mv public/img/map/ public/map/img/map/
       - name: Publish map site build for map.nycmesh.net to fetch and host
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/map-build.yaml
+++ b/.github/workflows/map-build.yaml
@@ -4,6 +4,7 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["master"]
+  pull-request:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/map-build.yaml
+++ b/.github/workflows/map-build.yaml
@@ -54,3 +54,4 @@ jobs:
         with:
           name: map-site-build
           path: public/map/
+          retention-days: 7

--- a/.github/workflows/map-build.yaml
+++ b/.github/workflows/map-build.yaml
@@ -1,0 +1,68 @@
+name: Deploy to GitHub Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  pull_request:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+# Default to bash
+defaults:
+  run:
+    shell: bash
+
+env:
+  NODE_OPTIONS: '--openssl-legacy-provider'
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.69.2
+    steps:
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+      - name: Install Dart Sass
+        run: sudo snap install dart-sass
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+      - name: Install Node.js dependencies
+        run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
+      - name: Update map
+        run: sh update-map.sh
+      - name: Build with Hugo
+        env:
+          HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
+          HUGO_ENVIRONMENT: production
+        run: |
+          hugo \
+            --minify \
+            --baseURL "${{ steps.pages.outputs.base_url }}/"
+      - name: Publish map site build for map.nycmesh.net to fetch and host
+        uses: actions/upload-artifact@v4
+        with:
+          name: map-site-build
+          path: public/map/

--- a/.github/workflows/map-build.yaml
+++ b/.github/workflows/map-build.yaml
@@ -53,8 +53,6 @@ jobs:
             --baseURL "https://map.nycmesh.net/"
       - name: Build Map Payload
         run:  |
-          mkdir -p public/map/map/
-          mv public/map/static/ public/map/map/static/
           mkdir -p public/map/img/
           mv public/img/map/ public/map/img/map/
           mv public/favicon.ico public/map/favicon.ico

--- a/.github/workflows/map-build.yaml
+++ b/.github/workflows/map-build.yaml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages
+name: Build distribution artifact for map.nycmesh.net
 
 on:
   # Runs on pushes targeting the default branch

--- a/content/map/_index.md
+++ b/content/map/_index.md
@@ -14,7 +14,7 @@ Hubs generally have a fast wireless connection and can connect other rooftops in
 
 Supernodes (SN) have fiber connections. Two of our supernodes are located at data centers with backbone internet connections. Our third supernode "131 Broome" is connected via leased fiber to the 111 8th Ave data center.
 
-If there is a supernode or hub node (blue dot) within range of your building, you may be able to join our network. The potential nodes are from our [join form](/join). We are working to turn these into active nodes by expanding our coverage and increasing our rate of installs.
+If there is a supernode or hub node (blue dot) within range of your building, you may be able to join our network. The potential nodes are from our [join form]({{< ref "/join" >}}). We are working to turn these into active nodes by expanding our coverage and increasing our rate of installs.
 
 The blue lines are over-the-air connections, yellow are fiber, purple are VPN and gray lines are speculative connections.
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,7 +2,7 @@
 	<div class="ph4-ns ph3 pv5">
 		<div class="mw8 center flex flex-wrap f5">
 			<div class="w-20-l w-100 flex items-start justify-start mb0-l mb4">
-				<a href="/" title="Home" class="f4 fw7 black mb0-l mb3">
+				<a href="{{ absURL "/" }}" title="Home" class="f4 fw7 black mb0-l mb3">
                     <div class="h2 w2">
 	                    {{ partial "logo.svg" . }}
 	                </div>
@@ -13,10 +13,10 @@
 				<ul class="list ma0 pa0 flex flex-column items-start">
 					<li class="mv2"><a href="https://slack.nycmesh.net" class="link mid-gray">Slack</a></li>
 					<li class="mv2"><a href="https://meetup.com/nycmesh" class="link mid-gray">Meetup</a></li>
-					<li class="mv2"><a href="/volunteer" class="link mid-gray">Volunteer</a></li>
+					<li class="mv2"><a href="{{ absURL "/volunteer" }}" class="link mid-gray">Volunteer</a></li>
 					<li class="mv2"><a href="https://us9.campaign-archive.com/home/?u=cf667149616fd293afa115f5a&id=ebe72854f3" class="link mid-gray">Newsletter</a></li>
-					<li class="mv2"><a href="/blog" class="link mid-gray">Blog</a></li>
-					<li class="mv2"><a href="/coc" class="link mid-gray">Code of Conduct</a></li>
+					<li class="mv2"><a href="{{ absURL "/blog" }}" class="link mid-gray">Blog</a></li>
+					<li class="mv2"><a href="{{ absURL "/coc" }}" class="link mid-gray">Code of Conduct</a></li>
 				</ul>
 			</div>
 			<div class="w-20-l w-50 mb0-l mb4">
@@ -25,7 +25,7 @@
 					<li class="mv2"><a href="https://status.nycmesh.net" class="link mid-gray">Network Status</a></li>
 					<li class="mv2"><a href="https://stats.nycmesh.net" class="link mid-gray">Stats</a></li>
 					<li class="mv2"><a href="https://wiki.nycmesh.net/link/98#bkmrk-page-title" class="link mid-gray">Peering</a></li>
-					<li class="mv2"><a href="/sponsors" class="link mid-gray">Sponsors</a></li>
+					<li class="mv2"><a href="{{ absURL "/sponsors" }}" class="link mid-gray">Sponsors</a></li>
 				</ul>
 			</div>
 			<div class="w-20-l w-50 mb0-l">
@@ -34,10 +34,10 @@
 					<li class="mv2"><a href="https://wiki.nycmesh.net/books/introduction/page/frequently-asked-questions" class="link mid-gray">FAQ</a></li>
 					<li class="mv2"><a href="https://wiki.nycmesh.net" class="link mid-gray" target="_">Documentation (Wiki)</a></li>
 					<li class="mv2"><a href="https://los.nycmesh.net" class="link mid-gray" target="_">Line of Sight</a></li>
-					<li class="mv2"><a href="/presentations" class="link mid-gray">Presentations</a></li>
+					<li class="mv2"><a href="{{ absURL "/presentations" }}" class="link mid-gray">Presentations</a></li>
 					<li class="mv2"><a href="https://wiki.nycmesh.net/link/123#bkmrk-page-title" class="link mid-gray" target="_">Outreach</a></li>
-					<li class="mv2"><a href="/pay" class="link mid-gray" target="_">Install Payment</a></li>
-					<li class="mv2"><a href="/orgdocs" class="link mid-gray">Public Records</a></li>
+					<li class="mv2"><a href="{{ absURL "/pay" }}" class="link mid-gray" target="_">Install Payment</a></li>
+					<li class="mv2"><a href="{{ absURL "/orgdocs" }}" class="link mid-gray">Public Records</a></li>
 				</ul>
 			</div>
 			<div class="w-20-l w-50">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,7 +1,7 @@
 <header class="pa3 bg-white">
 	<div class="mw8 center w-100 flex items-center justify-between relative">
 		<div class="flex">
-                <a href="/" title="Home" class="f3-ns f4 fw7 black">
+                <a href="{{ absURL "/" }}" title="Home" class="f3-ns f4 fw7 black">
                     <div class="nowrap flex items-center">
                         <div class="h2 w2">
                             {{ partial "logo.svg" . }}
@@ -20,11 +20,11 @@
 		<a href="/map" class="ml3-ns black pointer-events">Map</a>
         <a href="https://wiki.nycmesh.net/books/introduction/page/frequently-asked-questions" class="ml3-ns black pointer-events">FAQ</a>
         <a href="https://wiki.nycmesh.net" class="ml3-ns black pointer-events">Docs/Wiki</a>
-        <a href="/blog" class="ml3-ns black pointer-events">Blog</a>
+        <a href="{{ absURL "/blog" }}" class="ml3-ns black pointer-events">Blog</a>
         <a href="https://nycmesh.creator-spring.com/" class="ml3-ns black pointer-events">Merch</a>
-        <a href="/support" class="ml3-ns black pointer-events green fw5">Get Support</a>
-        <a href="/donate" class="ml3-ns black pointer-events">Donate</a>
-        <a href="/join" class="ml3-ns black pointer-events blue fw5">Get Connected</a>
+        <a href="{{ absURL "/support" }}" class="ml3-ns black pointer-events green fw5">Get Support</a>
+        <a href="{{ absURL "/donate" }}" class="ml3-ns black pointer-events">Donate</a>
+        <a href="{{ absURL "/join" }}" class="ml3-ns black pointer-events blue fw5">Get Connected</a>
         </nav>
 	</div>
     <script>

--- a/update-map.sh
+++ b/update-map.sh
@@ -4,11 +4,11 @@ rm -rf resources/node-map/
 git clone https://github.com/nycmeshnet/network-map resources/node-map
 cd resources/node-map
 if [ -n "$STANDALONE_MAP_BUILD" ]; then
-  sed -i.tmp 's/basename="\/map"/basename="\/"/' src/App.js
+  sed -i.tmp 's|basename="/map"|basename="/"|' src/App.js
   rm src/App.js.tmp
-  sed -i.tmp 's/href="\/map\/nodes\//href="\/nodes\//' src/components/Stats/component.js
+  sed -i.tmp 's|href="/map/nodes/|href="/nodes/|' src/components/Stats/component.js
   rm src/components/Stats/component.js.tmp
-  sed -i.tmp 's/"homepage": "\/map"/"homepage": "\/"/' package.json
+  sed -i.tmp 's|"homepage": "/map"|"homepage": "/"|' package.json
   rm package.json.tmp
 fi
 npm run update-data

--- a/update-map.sh
+++ b/update-map.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 set -e
 rm -rf resources/node-map/
-git clone https://github.com/olivernyc/node-map resources/node-map
+git clone https://github.com/nycmeshnet/network-map resources/node-map
 cd resources/node-map
 npm run update-data
 npm install

--- a/update-map.sh
+++ b/update-map.sh
@@ -4,9 +4,12 @@ rm -rf resources/node-map/
 git clone https://github.com/nycmeshnet/network-map resources/node-map
 cd resources/node-map
 if [ -n "$STANDALONE_MAP_BUILD" ]; then
-  sed -i '' 's/basename="\/map"/basename="\/"/' src/App.js
-  sed -i '' 's/href="\/map\/nodes\//href="\/nodes\//' src/components/Stats/component.js
-  sed -i '' 's/"homepage": "\/map"/"homepage": "\/"/' package.json
+  sed -i.tmp 's/basename="\/map"/basename="\/"/' src/App.js
+  rm src/App.js.tmp
+  sed -i.tmp 's/href="\/map\/nodes\//href="\/nodes\//' src/components/Stats/component.js
+  rm src/components/Stats/component.js.tmp
+  sed -i.tmp 's/"homepage": "\/map"/"homepage": "\/"/' package.json
+  rm package.json.tmp
 fi
 npm run update-data
 npm install

--- a/update-map.sh
+++ b/update-map.sh
@@ -3,6 +3,11 @@ set -e
 rm -rf resources/node-map/
 git clone https://github.com/nycmeshnet/network-map resources/node-map
 cd resources/node-map
+if [[ -n "$STANDALONE_MAP_BUILD" ]]; then
+  sed -i '' 's|basename="/map"|basename="/"|' src/App.js
+  sed -i '' 's|href="/map/nodes/|href="/nodes/|' src/components/Stats/component.js
+  sed -i '' 's|"homepage": "/map"|"homepage": "/"|' package.json
+fi
 npm run update-data
 npm install
 npm run build

--- a/update-map.sh
+++ b/update-map.sh
@@ -1,12 +1,12 @@
 #! /bin/sh
-set -e
+set -ex
 rm -rf resources/node-map/
 git clone https://github.com/nycmeshnet/network-map resources/node-map
 cd resources/node-map
-if [[ -n "$STANDALONE_MAP_BUILD" ]]; then
-  sed -i '' 's|basename="/map"|basename="/"|' src/App.js
-  sed -i '' 's|href="/map/nodes/|href="/nodes/|' src/components/Stats/component.js
-  sed -i '' 's|"homepage": "/map"|"homepage": "/"|' package.json
+if [ -n "$STANDALONE_MAP_BUILD" ]; then
+  sed -i '' 's/basename="\/map"/basename="\/"/' src/App.js
+  sed -i '' 's/href="\/map\/nodes\//href="\/nodes\//' src/components/Stats/component.js
+  sed -i '' 's/"homepage": "\/map"/"homepage": "\/"/' package.json
 fi
 npm run update-data
 npm install


### PR DESCRIPTION
Add a github action which builds an artifact specifically for map.nycmesh.net

Doing the build here ensures we're kept up to date with the latest website format changes and we always look identical in the subdomain

Also converts all URLs on the map page to absolute URLs so that when we move where that page is hosted, the links all still work