### PR TITLE
Redirect /map to map.nycmesh.net

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -17,7 +17,7 @@
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-menu"><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
         </div>
         <nav class="f5 flex items-center dropdown-content pointer-events-none bg-white">
-		<a href="/map" class="ml3-ns black pointer-events">Map</a>
+		<a href="https://map.nycmesh.net" class="ml3-ns black pointer-events">Map</a>
         <a href="https://wiki.nycmesh.net/books/introduction/page/frequently-asked-questions" class="ml3-ns black pointer-events">FAQ</a>
         <a href="https://wiki.nycmesh.net" class="ml3-ns black pointer-events">Docs/Wiki</a>
         <a href="{{ absURL "/blog" }}" class="ml3-ns black pointer-events">Blog</a>

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,4 +1,5 @@
-/map/nodes/*    /map   200
+/map            https://map.nycmesh.net/
+/map/nodes/*    https://map.nycmesh.net/nodes/:splat
 /data			/faq/#data
 /peering        https://docs.nycmesh.net/networking/peering/
 /youtube		https://www.youtube.com/channel/UC3FH_8A4SDtJbo5UWMhBteA

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,4 +1,4 @@
-/map            https://map.nycmesh.net/
+/map            https://map.nycmesh.net/    302!
 /map/nodes/*    https://map.nycmesh.net/nodes/:splat
 /data			/faq/#data
 /peering        https://docs.nycmesh.net/networking/peering/


### PR DESCRIPTION
In support of the MeshDB launch, we need to move the map page to be hosted at `map.nycmesh.net`

This change preserves all existing map features, and all existing deep-links will continue to operate as normal. We expect this redirect will be in place indefinitely, as there are a large number of links to the map circulating in the wild that we do not want to break