### PR TITLE
Add custom 404 page

### DIFF
--- a/.github/workflows/map-build.yaml
+++ b/.github/workflows/map-build.yaml
@@ -52,6 +52,7 @@ jobs:
           mkdir -p public/map/img/
           mv public/img/map/ public/map/img/map/
           mv public/favicon.ico public/map/favicon.ico
+          mv public/404.html public/map/
       - name: Publish map site build for map.nycmesh.net to fetch and host
         uses: actions/upload-artifact@v4
         with:

--- a/content/404.md
+++ b/content/404.md
@@ -1,0 +1,10 @@
+---
+title: "NYC Mesh - 404 Page Not Found"
+description: "404 Page not found"
+url: "/404.html"
+---
+
+The page you're looking for could not be found. Please double-check the entered URL, or try again later
+
+
+### <a href="{{< ref "/" >}}" class="blue">← Return to nycmesh.net homepage</a>


### PR DESCRIPTION
Adds a custom 404 page, instead of using the Netlify default. This allows us to create a consistent experience even if parts of the the site are not hosted on Netlify

Netlify will [automatically serve](https://docs.netlify.com/routing/redirects/redirect-options/#custom-404-page-handling) 404.html if it is provided in the output.

Also removes 404.html from the layout templates to reduce confusion. This was unused

Finally, we copy the new 404 page into the map ZIP builds so that it can be used on map.nycmesh.net