### PR TITLE
Add link for troubleshooting guide to /support

### DIFF
--- a/content/support/_index.md
+++ b/content/support/_index.md
@@ -11,13 +11,11 @@ For subscription or donation problems go to [nycmesh.net/payquery](../payquery)
 
 Is something not working right? Here’s how you can fix it:
 
-1. Check the [network status](/network-status) to see whether other people are affected. If you see the issue here it means our volunteers are working on solving it, and we’ll be posting more updates!
+1. Check the [network status page](https://status.nycmesh.net) to see to see if there's a known outage or planned maintenance occuring. If you see the issue here it means our volunteers are already working on solving it. Please reach out if you're still having problems after the issue has been marked as resolved.
 
-2. For real-time interaction, ask a question on our [Slack](https://slack.nycmesh.net/) #support channel.
+2. Follow our [Member Troubleshooting Guide](https://wiki.nycmesh.net/link/44#bkmrk-page-title) for steps to try and solve common issues yourself.
 
-3. Fill out the support request form below!
+3. Ask for support on our [Slack](https://slack.nycmesh.net/) #support channel. Volunteers monitor this channel and can respond quickly to issues.<br>
+If you're having issues with your DIY install, reach out in the #diy-install-support channel.
 
-For DIY, you can fill in this support form, and also ask a question on our [Slack](https://slack.nycmesh.net/) #diy-install-support channel, or try using our [docs](https://docs.nycmesh.net/) to solve the issue yourself.
-
-
-
+3. Fill out the support request form below. One of our volunteers will respond to your request shortly!


### PR DESCRIPTION
Update support with link to troubleshooting guide to help members troubleshoot their own problems.
Also updates status page link to new URL.