### PR TITLE
Nicer redirects

### DIFF
--- a/content/map/_index.md
+++ b/content/map/_index.md
@@ -14,7 +14,7 @@ Hubs generally have a fast wireless connection and can connect other rooftops in
 
 Supernodes (SN) have fiber connections. Two of our supernodes are located at data centers with backbone internet connections. Our third supernode "131 Broome" is connected via leased fiber to the 111 8th Ave data center.
 
-If there is a supernode or hub node (blue dot) within range of your building, you may be able to join our network. The potential nodes are from our [join form](https://forms.nycmesh.net/join). We are working to turn these into active nodes by expanding our coverage and increasing our rate of installs.
+If there is a supernode or hub node (blue dot) within range of your building, you may be able to join our network. The potential nodes are from our [join form](https://forms.nycmesh.net/join/). We are working to turn these into active nodes by expanding our coverage and increasing our rate of installs.
 
 The blue lines are over-the-air connections, yellow are fiber, purple are VPN and gray lines are speculative connections.
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -24,7 +24,7 @@
         <a href="https://nycmesh.creator-spring.com/" class="ml3-ns black pointer-events">Merch</a>
         <a href="{{ absURL "/support" }}" class="ml3-ns black pointer-events green fw5">Get Support</a>
         <a href="{{ absURL "/donate" }}" class="ml3-ns black pointer-events">Donate</a>
-        <a href="https://forms.nycmesh.net/join" class="ml3-ns black pointer-events blue fw5">Get Connected</a>
+        <a href="https://forms.nycmesh.net/join/" class="ml3-ns black pointer-events blue fw5">Get Connected</a>
         </nav>
 	</div>
     <script>

--- a/static/_redirects
+++ b/static/_redirects
@@ -12,10 +12,10 @@
 /panorama/1.7miles.png /img/1.7miles.png
 /network-status https://status.mesh.nycmesh.net
 /status https://status.mesh.nycmesh.net
-/nn https://forms.nycmesh.net/nn-assign 302!  #redirect /nn to MeshDB version of the page
-/query https://forms.nycmesh.net/query 302! #redirect /query to MeshDB version of the page
-/join https://forms.nycmesh.net/join
+/nn https://forms.nycmesh.net/nn-assign/ 302!  #redirect /nn to MeshDB version of the page
+/query https://forms.nycmesh.net/query/ 302! #redirect /query to MeshDB version of the page
+/join https://forms.nycmesh.net/join/
 /es/join https://forms.nycmesh.net/es/join/
 /zh/join https://forms.nycmesh.net/zh/join/
-/connect https://forms.nycmesh.net/join
+/connect https://forms.nycmesh.net/join/
 /faq https://wiki.nycmesh.net/link/153#bkmrk-page-title


### PR DESCRIPTION
The join for redirects `/join` to `/join/`. Do this in the original redirect to save redirect.