### PR TITLE
Fix nil pointer error in baseof.html for taxonomy pages

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -20,14 +20,14 @@
 </head>
 <body class="helvetica flex flex-column justify-between" style="minHeight: 100vh">
     <div>
-        {{ if ne .Page.File.TranslationBaseName "join" }}
+	{{ if and .Page.File (ne .Page.File.TranslationBaseName "join") }}
         {{ partial "alert" . }}
         {{ end }}
         {{ partial "header" . }}
         {{ block "main" . }}
         {{ end }}
     </div>
-    {{ if ne .Page.File.TranslationBaseName "join" }}
+    {{ if and .Page.File (ne .Page.File.TranslationBaseName "join") }}
     {{ partial "footer" . }}
     {{ end }}
 </body>


### PR DESCRIPTION
Hi! A friend asked me for help on how to add new entries to the blog, so I started exploring the site locally and installed Hugo to test the changes.

While doing so, I noticed that the site wouldn't render correctly due to the following error when accessing pages like `/tags`, `/categories`, or specific tag pages:

```
runtime error: invalid memory address or nil pointer dereference
```

After some investigation, I found that the issue was caused by this line in `layouts/_default/baseof.html`:

```gohtml
{{ if ne .Page.File.TranslationBaseName "join" }}
```

This line assumes `.Page.File` is always present. However, Hugo does not assign a `.File` object to taxonomy or autogenerated list pages, so trying to access `.TranslationBaseName` on a `nil` value causes the build to fail.

To solve this and allow the site to render properly, I replaced the condition with a safer version:

```gohtml
{{ if and .Page.File (ne .Page.File.TranslationBaseName "join") }}
```

This change ensures `.TranslationBaseName` is only accessed if `.Page.File` exists, avoiding the crash.

With this fix, the site renders correctly again, including all taxonomy pages, making it easier for contributors (like my friend!) to preview their posts locally without issues.

Let me know if anything else needs to be adjusted.