### PR TITLE
aliases typo

### DIFF
--- a/content/165upgrade/index.md
+++ b/content/165upgrade/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Grand Street Guild - 165 Broome Upgrade"
-allias: "/165upgrade"
+aliases: ["/165upgrade"]
 
 ---
 

--- a/content/olmsted/index.md
+++ b/content/olmsted/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Olmsted Information"
-allias: "/olmsted"
+aliases: ["/olmsted"]
 ---
 
 ---


### PR DESCRIPTION
While working on another part of the site, I noticed a typo which Hugo would fail silently in olmsted and 165upgrade. "allias" tag corrected to "aliases". Redirect should work properly at build time now.