### PR TITLE
replace template with redirect html

### DIFF
--- a/layouts/redirect/single.html
+++ b/layouts/redirect/single.html
@@ -1,1 +1,13 @@
-{{- template "_internal/alias.html" (dict "Permalink" .Params.target) -}}
+<!DOCTYPE html>
+<html lang="{{ .Site.Language.Lang }}">
+  <head>
+    <meta charset="utf-8">
+    <title>{{ .Title }}</title>
+    <link rel="canonical" href="{{ .Params.target }}">
+    <meta name="robots" content="noindex">
+    <meta http-equiv="refresh" content="0; url={{ .Params.target }}">
+  </head>
+  <body>
+    <p>Redirecting to <a href="{{ .Params.target }}">{{ .Params.target }}</a>...</p>
+  </body>
+</html>


### PR DESCRIPTION
I noticed that the repo setup instructions of:
```
brew install hugo
hugo serve
```
Failed with the latest editions of `hugo`, due to updates in the internal redirect templates.

So i replaced the template with redirect HTML.