### PR TITLE
Centralize Stripe publishable key in config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,6 +9,7 @@ summaryLength = 10
   title = "NYC Mesh"
   description = "Join our community-owned network to replace your current internet connection."
   images = ["/img/3d.png"]
+  stripeKey = "pk_live_srTdi5OfErTSw5BGXqEkY9C1"
 
 [languages]
   [languages.en]

--- a/layouts/clemente/section.html
+++ b/layouts/clemente/section.html
@@ -197,7 +197,7 @@ input[type=number]::-webkit-outer-spin-button {
     }
 
     var stripeConfig = {
-      key: 'pk_live_srTdi5OfErTSw5BGXqEkY9C1',
+      key: '{{ .Site.Params.stripeKey }}',
       image: '/img/logo.svg',
       locale: 'auto',
       billingAddress: true,

--- a/layouts/donate/section.html
+++ b/layouts/donate/section.html
@@ -159,7 +159,7 @@
     }
 
     var stripeConfig = {
-      key: 'pk_live_srTdi5OfErTSw5BGXqEkY9C1',
+      key: '{{ .Site.Params.stripeKey }}',
       image: '/img/logo.svg',
       locale: 'auto',
       billingAddress: true,

--- a/layouts/invoice/section.html
+++ b/layouts/invoice/section.html
@@ -147,7 +147,7 @@ input[type=number]::-webkit-outer-spin-button {
     }
 
     var stripeConfig = {
-      key: "pk_live_srTdi5OfErTSw5BGXqEkY9C1",
+      key: "{{ .Site.Params.stripeKey }}",
       image: "/img/logo.svg",
       locale: "auto",
       billingAddress: true,

--- a/layouts/pay/section.html
+++ b/layouts/pay/section.html
@@ -195,7 +195,7 @@ Thank you for choosing to cover the full cost of equipment.
     }
 
     var stripeConfig = {
-      key: 'pk_live_srTdi5OfErTSw5BGXqEkY9C1',
+      key: '{{ .Site.Params.stripeKey }}',
       image: '/img/logo.svg',
       locale: 'auto',
       billingAddress: true,

--- a/layouts/pay110/section.html
+++ b/layouts/pay110/section.html
@@ -193,7 +193,7 @@ input[type=number]::-webkit-outer-spin-button {
     }
 
     var stripeConfig = {
-      key: 'pk_live_srTdi5OfErTSw5BGXqEkY9C1',
+      key: '{{ .Site.Params.stripeKey }}',
       image: '/img/logo.svg',
       locale: 'auto',
       billingAddress: true,

--- a/layouts/pay240/section.html
+++ b/layouts/pay240/section.html
@@ -195,7 +195,7 @@ Thank you for choosing to cover the full cost of equipment.
     }
 
     var stripeConfig = {
-      key: 'pk_live_srTdi5OfErTSw5BGXqEkY9C1',
+      key: '{{ .Site.Params.stripeKey }}',
       image: '/img/logo.svg',
       locale: 'auto',
       billingAddress: true,

--- a/layouts/pay40/section.html
+++ b/layouts/pay40/section.html
@@ -197,7 +197,7 @@ Please remember to pay the installer <b>$50</b>.
     }
 
     var stripeConfig = {
-      key: 'pk_live_srTdi5OfErTSw5BGXqEkY9C1',
+      key: '{{ .Site.Params.stripeKey }}',
       image: '/img/logo.svg',
       locale: 'auto',
       billingAddress: true,

--- a/layouts/payolmsted/section.html
+++ b/layouts/payolmsted/section.html
@@ -188,7 +188,7 @@ input[type=number]::-webkit-outer-spin-button {
     }
 
     var stripeConfig = {
-      key: 'pk_live_srTdi5OfErTSw5BGXqEkY9C1',
+      key: '{{ .Site.Params.stripeKey }}',
       image: '/img/logo.svg',
       locale: 'auto',
       billingAddress: true,


### PR DESCRIPTION
## Summary
  - Moves the Stripe publishable key from 8 hardcoded instances in payment layout templates to a single `stripeKey`
  param in `config.toml`
  - Makes key rotation and test/live switching a one-line change instead of editing 8 files

  ## Changed files
  - `config.toml` — added `stripeKey` under `[params]`
  - 8 payment layouts now reference `{{ .Site.Params.stripeKey }}` instead of the hardcoded key

  ## Test plan
  - [ ] Verify Netlify deploy preview builds successfully
  - [ ] Test payment flow on `/donate` page
  - [ ] Test payment flow on `/pay` page
  - [ ] Confirm Stripe modal opens with correct key (inspect network requests)